### PR TITLE
confirm that the message is not a webhook

### DIFF
--- a/activeRole.js
+++ b/activeRole.js
@@ -2,7 +2,8 @@ const config = require("./config.json");
 const ONE_HOUR = 3600000;
 
 exports.checkActiveRole = function (message) {
-  if (
+  if ( 
+    !message.webhookId &&
     message.channel.guild.id === config.mainServer &&
     !hasRole(message.member, message.channel.guild, "active")
   ) {


### PR DESCRIPTION
The final return of the role will crash if the message is actually a webhook rather than a user. This should now check for a webhook first. Alternatively add a `if (message.webhookId) return;` before the if statement.