### PR TITLE
Fixes automod crash

### DIFF
--- a/activeRole.js
+++ b/activeRole.js
@@ -3,7 +3,6 @@ const util = require("./util");
 
 exports.checkActiveRole = async function (message, guild, db) {
   if (
-    !message.webhookId &&
     message.member &&
     message.channel.guild.id === config.mainServer &&
     !hasRole(message.member, message.channel.guild, "active")

--- a/activeRole.js
+++ b/activeRole.js
@@ -3,6 +3,7 @@ const util = require("./util");
 
 exports.checkActiveRole = async function (message, guild, db) {
   if (
+    message.inGuild() &&
     message.member &&
     message.channel.guild.id === config.mainServer &&
     !hasRole(message.member, message.channel.guild, "active")

--- a/activeRole.js
+++ b/activeRole.js
@@ -4,6 +4,7 @@ const util = require("./util");
 exports.checkActiveRole = async function (message, guild, db) {
   if (
     !message.webhookId &&
+    message.member &&
     message.channel.guild.id === config.mainServer &&
     !hasRole(message.member, message.channel.guild, "active")
   ) {


### PR DESCRIPTION
Automod uses a different type of webhook which is not caught by the `!webhook` check. Now checking if the message is from a guild member instead. Confirmed that the new bot webhooks which do have a member profile do not have a member property so for d.js v13 at least this is a better check.