### PR TITLE
fix: the addaward command does not perform authoriza... in addaward.js

### DIFF
--- a/commands/mod/addaward.js
+++ b/commands/mod/addaward.js
@@ -1,4 +1,10 @@
+const { isMod } = require("../../util");
+
 exports.interaction = function (interaction, bot, db) {
+  if (!isMod(interaction.member, interaction.guild)) {
+    interaction.reply({ content: ":no_entry: You do not have permission to use this command.", ephemeral: true });
+    return;
+  }
   const member = interaction.options.getMember("member");
   const awardText = interaction.options.getString("text");
   db.query(


### PR DESCRIPTION
## Summary
Fix high severity security issue in `commands/mod/addaward.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `commands/mod/addaward.js:1` |
| **Assessment** | Likely exploitable |

**Description**: The addaward command does not perform authorization checks to verify the user has moderator permissions. Unlike other moderation commands that use isMod() function, this command allows any Discord server member to add awards.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `commands/mod/addaward.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
